### PR TITLE
feat: create member (POST /members)

### DIFF
--- a/src/members/dto/create-member.dto.ts
+++ b/src/members/dto/create-member.dto.ts
@@ -1,1 +1,33 @@
-export class CreateMemberDto {}
+import {
+  IsBoolean,
+  IsEmail,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+} from 'class-validator';
+
+export class CreateMemberDto {
+  @IsInt()
+  roleId: number;
+
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(255)
+  name: string;
+
+  @IsEmail()
+  @MaxLength(255)
+  email: string;
+
+  @IsOptional()
+  @IsUrl()
+  @MaxLength(2048)
+  photo?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isVisible?: boolean;
+}

--- a/src/members/entities/member.entity.ts
+++ b/src/members/entities/member.entity.ts
@@ -1,1 +1,2 @@
-export class Member {}
+import { members } from 'drizzle/schema';
+export type Member = typeof members.$inferSelect;

--- a/src/members/members.controller.ts
+++ b/src/members/members.controller.ts
@@ -7,6 +7,8 @@ import {
   Param,
   Delete,
   UseGuards,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import { MembersService } from './members.service';
 import { CreateMemberDto } from './dto/create-member.dto';
@@ -18,6 +20,7 @@ export class MembersController {
   constructor(private readonly membersService: MembersService) {}
 
   @Post()
+  @HttpCode(HttpStatus.CREATED)
   create(@Body() createMemberDto: CreateMemberDto) {
     return this.membersService.create(createMemberDto);
   }

--- a/src/members/members.service.ts
+++ b/src/members/members.service.ts
@@ -1,10 +1,16 @@
-import { Inject, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { CreateMemberDto } from './dto/create-member.dto';
 import { UpdateMemberDto } from './dto/update-member.dto';
 import {
   DATABASE_CONNECTION,
   Database,
 } from 'src/database/database-connection';
+import { members } from 'drizzle/schema';
 
 @Injectable()
 export class MembersService {
@@ -12,8 +18,35 @@ export class MembersService {
     @Inject(DATABASE_CONNECTION)
     private readonly db: Database,
   ) {}
-  create(createMemberDto: CreateMemberDto) {
-    return 'This action adds a new member';
+
+  async create(createMemberDto: CreateMemberDto) {
+    try {
+      const [newMember] = await this.db
+        .insert(members)
+        .values({
+          ...createMemberDto,
+          // NOTE: the database default for is_visible is actually false
+          // but the API specifies it should be true
+          // https://github.com/SAMAHAN-Systems-Development/sysdev-website-backend/issues/9
+          isVisible: createMemberDto.isVisible ?? true,
+        })
+        .returning();
+
+      return newMember;
+    } catch (error) {
+      console.error(error.code);
+      if (error.code === '23503') {
+        // PostgreSQL Foreign Key Error code 23503
+        // catches when roleId does not refer to an existing role in the DB
+        throw new BadRequestException('Role ID does not exist');
+      }
+      if (error instanceof BadRequestException) {
+        // Re-throw validation errors as is
+        throw error;
+      }
+      console.error('Failed to create member:', error);
+      throw new InternalServerErrorException('Failed to create member');
+    }
   }
 
   findAll() {


### PR DESCRIPTION
Add new POST endpoint `/members`

## Notes:

- Endpoint is `/members` not `/api/members`
- A few notes in the `src/members/members.service.create()` function
- Member entity is a **type** not a class, directly inferred from the drizzle schema:
```js
// src/members/entities/member.entity.ts
// this is the whole file
import { members } from 'drizzle/schema';
export type Member = typeof members.$inferSelect;
```