### PR TITLE
feat: delete project (DELETE /projects/:id)

### DIFF
--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -13,7 +13,7 @@ import { CreateProjectDto } from './dto/create-project.dto';
 import { UpdateProjectDto } from './dto/update-project.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt.guard';
 
-@Controller('project')
+@Controller('projects')
 @UseGuards(JwtAuthGuard)
 export class ProjectController {
   constructor(private readonly projectService: ProjectService) {}

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -7,6 +7,8 @@ import {
   Param,
   Delete,
   UseGuards,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import { ProjectService } from './project.service';
 import { CreateProjectDto } from './dto/create-project.dto';
@@ -39,6 +41,7 @@ export class ProjectController {
   }
 
   @Delete(':id')
+  @HttpCode(HttpStatus.OK)
   remove(@Param('id') id: string) {
     return this.projectService.remove(+id);
   }

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -1,4 +1,10 @@
-import { Inject, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { CreateProjectDto } from './dto/create-project.dto';
 import { UpdateProjectDto } from './dto/update-project.dto';
 import {
@@ -6,6 +12,7 @@ import {
   DATABASE_CONNECTION,
 } from 'src/database/database-connection';
 import { projects } from 'drizzle/schema';
+import { and, eq, isNull } from 'drizzle-orm';
 
 @Injectable()
 export class ProjectService {
@@ -29,7 +36,45 @@ export class ProjectService {
     return `This action updates a #${id} project`;
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} project`;
+  async remove(id: number) {
+    try {
+      // Soft-delete the project if not already deleted
+      const [updatedProject] = await this.db
+        .update(projects)
+        .set({ deletedAt: new Date() })
+        .where(and(eq(projects.id, id), isNull(projects.deletedAt)))
+        .returning();
+
+      // If nothing was deleted, query again to find out why
+      if (!updatedProject) {
+        const [existing] = await this.db
+          .select()
+          .from(projects)
+          .where(eq(projects.id, id))
+          .limit(1);
+
+        if (!existing) {
+          throw new NotFoundException(`Project with ID ${id} not found.`);
+        } else {
+          throw new BadRequestException(
+            `Project with ID ${id} is already deleted.`,
+          );
+        }
+      }
+
+      return updatedProject;
+    } catch (error) {
+      if (
+        error instanceof BadRequestException ||
+        error instanceof NotFoundException
+      ) {
+        // Re-throw validation and not found errors as is
+        throw error;
+      }
+      console.error(`Failed to delete project ID ${id}:`, error);
+      throw new InternalServerErrorException(
+        `Failed to delete project ID ${id}.`,
+      );
+    }
   }
 }


### PR DESCRIPTION
Add new DELETE endpoint `/projects/:id`

## Notes:

- Endpoint is `/projects` not `/api/projects`
- Controller does not use ParseIntPipe for ID, leading to Internal Server Error NaN when trying to non-numeric IDs
  - Possible solutions:
    - Do nothing; let the DB take a hit, intentionally Error on NaN, and raise Not Found for Negative IDs
    - Manually check IDs in every endpoint (not just this one)
    - Create a `ParseIdPipe` globally with `nest g pipe common/pipes/parse-id`, creating a new `common/pipes/` folder